### PR TITLE
Add requirements file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 count = true
-exclude = cards,.flake8,.git,.travis.yml
+exclude = cards,.flake8,.git,.travis.yml,requirements.txt
 format = pylint
 max_line_length = 80
 max_complexity = 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  pip install flake8
+  pip install -r requirements.txt
 # command to run tests
 script:
   flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+##### Requirements for Punch Card #####
+flake8 >= 3.2.1


### PR DESCRIPTION
Add the `requirements.txt` file with the projects dependencies which is only flake8 at the momment.
Add requirements.txt to the exclude piece of the .flake8 file.
Modify .travis.yml script install section to use the requirements file in place of explicitly installing dependencies.

Closes #10