### PR TITLE
Add argparse library

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,6 @@
 count = true
 exclude = cards,.flake8,.git,.travis.yml,requirements.txt,.gitignore,*.in
 format = pylint
-max_line_length = 80
+max_line_length = 128
 max_complexity = 10
 show_source = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   pip install -r requirements.txt
 # command to run tests
 script:
-  flake8 && python -m unittest tests/PunchCard-test.py -v
+  flake8 && python -m unittest -bv tests/PunchCard-test.py

--- a/PunchCard.py
+++ b/PunchCard.py
@@ -1,3 +1,4 @@
+import argparse
 import fileinput
 
 
@@ -31,21 +32,66 @@ def calculateDay(dayEntry):
     return dayHours
 
 
-def main(input):
+def printDaysHours(day, hours, timeFormat):
+    floatHours = round(hours, 3)
+    intHours = int(floatHours)
+    intMinutes = int((floatHours - intHours)*60)
+    if timeFormat == 'HH.hhh':
+        print('{}: {} hours'.format(day, floatHours))
+    elif timeFormat == 'HH:mm':
+        print('{}: {} hours {} minutes'.format(day, intHours, intMinutes))
+    else:
+        print('{}: {} hours {} minutes({} hours)'.format(day, intHours, intMinutes, floatHours))
+
+
+def printWeekHours(hours, timeFormat):
+    floatHours = round(hours, 3)
+    intHours = int(floatHours)
+    intMinutes = int((floatHours - intHours)*60)
+    if timeFormat == 'HH.hhh':
+        print('\nTotal hours for the week: {} hours'.format(floatHours))
+    elif timeFormat == 'HH:mm':
+        print('\nTotal hours for the week: {} hours {} minutes'.format(intHours, intMinutes))
+    else:
+        print('\nTotal hours for the week: {} hours {} minutes({} hours)'.format(intHours, intMinutes, floatHours))
+
+
+def main(input, timeFormat):
     weekHours = 0.0
     print(input.pop(0))
     for line in input:
         daySplit = line.split(',')
         dayLetter = daySplit.pop(0)[0]
         dayHours = calculateDay(daySplit)
-        print(dayLetter + ': ' + str(dayHours))
+        printDaysHours(dayLetter, dayHours, timeFormat)
         weekHours += dayHours
 
-    print('\nTotal hours for the week: ' + str(weekHours))
+    printWeekHours(weekHours, timeFormat)
 
 
 if __name__ == '__main__':
+    description = 'This is a simple program meant to calculate my work hours.'
+    parser = argparse.ArgumentParser(description=description)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-H', '--hours', action='store_true', help='Outputs hours only as a decimal')
+    group.add_argument('-m', '--minutes', action='store_true', help='Outputs hours and minutes')
+    parser.add_argument('file', nargs='?', type=argparse.FileType('r'), default='-',
+                        help='The file to be read or if no file given read stdin')
+    args = parser.parse_args()
+
     lines = []
-    for line in fileinput.input():
-        lines.append(line)
-    main(lines)
+    if args.file.name == '<stdin>':
+        for line in fileinput.input('-'):
+            lines.append(line)
+    else:
+        for line in fileinput.input(args.file.name):
+            lines.append(line)
+
+    if args.hours:
+        timeFormat = 'HH.hhh'
+    elif args.minutes:
+        timeFormat = 'HH:mm'
+    else:
+        timeFormat = None
+
+    main(lines, timeFormat)

--- a/tests/PunchCard-test.py
+++ b/tests/PunchCard-test.py
@@ -40,9 +40,106 @@ class CalculateDayTests(unittest.TestCase):
     def test_returnsEight_givenTwoEntries(self):
         self.assertEqual(PunchCard.calculateDay(['8:00', '4:00']), 8.0)
 
+    def test_returnsEightHoursTenMinutesAsDecimal_givenTwoEntries(self):
+        self.assertEqual(PunchCard.calculateDay(['8:00', '4:10']), 8.166666666666666)
+
     def test_throwsError_givenAnIncorrectTime(self):
         with self.assertRaises(ValueError):
             PunchCard.calculateDay(['a', '10:00'])
+
+
+class PrintDaysHoursTests(unittest.TestCase):
+
+    def test_printsStringForDayWithHoursMinutesAndDecimalHours_givenNoTimeFormat(self):
+        PunchCard.printDaysHours('M', 8.166666666666666, None)
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'M: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForDayWithHoursMinutesAndDecimalHours_givenAnyStringAsATimeFormat(self):
+        PunchCard.printDaysHours('M', 8.166666666666666, 'aaa')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'M: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForDayWithHoursMinutesAndDecimalHours_givenAnyNumberAsATimeFormat(self):
+        PunchCard.printDaysHours('M', 8.166666666666666, 6.6)
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'M: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForDayWithHoursMinutes_givenTimeFormatHHmm(self):
+        PunchCard.printDaysHours('M', 8.166666666666666, 'HH:mm')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'M: 8 hours 10 minutes'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForDayWithDecimalHours_givenTimeFormatHHhhh(self):
+        PunchCard.printDaysHours('M', 8.166666666666666, 'HH.hhh')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'M: 8.167 hours'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_throwsError_givenAStringForHours(self):
+        with self.assertRaises(TypeError):
+            PunchCard.printDaysHours('M', 'a', 'HH.hhh')
+
+
+class PrintWeekHoursTests(unittest.TestCase):
+
+    def test_printsStringForWeekWithHoursMinutesAndDecimalHours_givenNoTimeFormat(self):
+        PunchCard.printWeekHours(8.166666666666666, None)
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'Total hours for the week: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForWeekWithHoursMinutesAndDecimalHours_givenAnyStringAsATimeFormat(self):
+        PunchCard.printWeekHours(8.166666666666666, 'aaa')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'Total hours for the week: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForWeekWithHoursMinutesAndDecimalHours_givenAnyNumberAsATimeFormat(self):
+        PunchCard.printWeekHours(8.166666666666666, 6.6)
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'Total hours for the week: 8 hours 10 minutes(8.167 hours)'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForWeekWithHoursMinutes_givenTimeFormatHHmm(self):
+        PunchCard.printWeekHours(8.166666666666666, 'HH:mm')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'Total hours for the week: 8 hours 10 minutes'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_printsStringForWeekWithDecimalHours_givenTimeFormatHHhhh(self):
+        PunchCard.printWeekHours(8.166666666666666, 'HH.hhh')
+        if not hasattr(sys.stdout, "getvalue"):
+            self.fail("need to run in buffered mode")
+        actualOutput = sys.stdout.getvalue().strip()
+        expectedOutput = 'Total hours for the week: 8.167 hours'
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def test_throwsError_givenAStringForHours(self):
+        with self.assertRaises(TypeError):
+            PunchCard.printWeekHours('a', 'HH.hhh')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. 	Add argparse library and set flags for program

    - Import argparse
    - Add a Argument Parser with a description.
    - Add a mutually exclusive group.
    - Add to the group two optional arguments H(hours) and m(minutes) with the action "store_true".
    - Add a positional argument file with type FileType('r') default set to '-' which is used for stdin so that when there is no file given to read it will read from stdin instead.
    - After calling parse_args check the file argument to see if it is reading from stdin or a file
    - Add logic to check which flag was used, H, m, None
    - Give the main function the array of lines read and the timeFormat which was decided based on the flags used if any.

    - Add new function printDayHours which takes a string for the day represented as a letter, a number which is the number of hours for that day, and the timeFormat. The time is calculated as decimal hours and int hours with int minutes. Then it decides which timeFormat is given and prints to screen based on that. The print line for each day in the main function is replaced with a call to this function instead.

    - Add new function printWeekHours which much like the printDayHours function takes the number of hours and timeFormat. Calculates the hours in different ways the same way. Decides the format the same way and then prints to screen accordingly. The print line for the week is replaced in the main function with a call to this function.

2. Increase max line length in .flake8 file
    - Since adding argparse the need to have lines longer than 80 has come up due to the add_argument call in argparse because it can be given various arguments including the help message which can take up extra space.

3. Add new tests to test the new methods

4. Update travis to use buffer flag when tests run

    - In order to test the methods that print but have no return, the unittest module needs to be run with the buffer flag.

Closes #18 